### PR TITLE
Fix problem about use github raw path

### DIFF
--- a/ijkplayer.podspec
+++ b/ijkplayer.podspec
@@ -21,7 +21,9 @@ bilibili/ijkplayer k0.8.3  IJKMediaFramework 上传到 cococapods
 
   s.platform     = :ios, "7.0"
 
-  s.source       = { :http => "https://raw.githubusercontent.com/iOSDevLog/ijkplayer/master/IJKMediaFramework.framework.zip" }
+  s.source       = { :git => "https://github.com/iOSDevLog/ijkplayer.git",
+                     :branch => 'master'
+                   }
 
   s.ios.vendored_frameworks = 'IJKMediaFramework.framework'
   s.frameworks  = "AudioToolbox", "AVFoundation", "CoreGraphics", "CoreMedia", "CoreVideo", "MobileCoreServices", "OpenGLES", "QuartzCore", "VideoToolbox", "Foundation", "UIKit", "MediaPlayer"


### PR DESCRIPTION
- use raw github path will got 404 error

```
[!] Error installing ijkplayer
[!] /usr/bin/curl -f -L -o /var/folders/wx/n2s849yx43q9bgzj9cv3c0hw0000gp/T/d20170928-31917-1xoaobt/file.zip https://raw.githubusercontent.com/iOSDevLog/ijkplayer/master/IJKMediaFramework.framework.zip --create-dirs --netrc-optional


curl: (22) The requested URL returned error: 404 Not Found
```

Change source to use git