### PR TITLE
Change to use github archive path

### DIFF
--- a/ijkplayer.podspec
+++ b/ijkplayer.podspec
@@ -21,9 +21,10 @@ bilibili/ijkplayer k0.8.3  IJKMediaFramework 上传到 cococapods
 
   s.platform     = :ios, "7.0"
 
-  s.source       = { :http => "https://raw.githubusercontent.com/iOSDevLog/ijkplayer/master/IJKMediaFramework.framework.zip" }
+  s.source       = { :http => "https://github.com/iOSDevLog/ijkplayer/archive/1.0.0.zip" }
 
-  s.ios.vendored_frameworks = 'IJKMediaFramework.framework'
+  s.vendored_frameworks = 'IJKMediaFramework.framework'
+
   s.frameworks  = "AudioToolbox", "AVFoundation", "CoreGraphics", "CoreMedia", "CoreVideo", "MobileCoreServices", "OpenGLES", "QuartzCore", "VideoToolbox", "Foundation", "UIKit", "MediaPlayer"
   s.libraries   = "bz2", "z", "stdc++"
 


### PR DESCRIPTION
Hello, I just change the podspece `source` to github archive path.

Next time you need release new version, just tag a new commit, and change the version on `s.source`. Don't need to zip framework again. 🎉

or use `"https://github.com/iOSDevLog/ijkplayer/archive/#{s.version}.zip"` to reference to spec.version number

BTW, use raw.githubusercontent.com is very slow when download zip.